### PR TITLE
openssl_lib_mock: Forcefully destroy mock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+sudo: required
+services:
+ - docker
+
+before_install:
+ - docker pull neverpanic/mococrw-build-env
+ - docker images
+
+script:
+  - mkdir build
+  - docker run --rm -t -v "$(readlink -f .):/src" -v "$(readlink -f build):/build" --workdir /build neverpanic/mococrw-build-env cmake -DCMAKE_BUILD_TYPE=Coverage -DBUILD_TESTING=On /src
+  - docker run --rm -t -v "$(readlink -f .):/src" -v "$(readlink -f build):/build" --workdir /build neverpanic/mococrw-build-env make -j2
+  - docker run --rm -t -v "$(readlink -f .):/src" -v "$(readlink -f build):/build" --workdir /build neverpanic/mococrw-build-env ctest -j2 --output-on-failure

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -2,8 +2,18 @@ project(mococrw)
 
 if(BUILD_TESTING) #set by Ctest. Also set in the integration build environment.
     if(NOT GMOCK_BOTH_LIBRARIES)
-        find_package(GMock REQUIRED CONFIG)
-        include_directories(SYSTEM ${GMOCK_INCLUDE_DIRS})
+        find_path(GMOCK_SRC_DIR
+            NAMES src/gmock-all.cc
+            PATHS /usr/src/gmock /usr/src/googletest/googlemock
+            NO_DEFAULT_PATH
+            ONLY_CMAKE_FIND_ROOT_PATH)
+        if(GMOCK_SRC_DIR)
+            message(STATUS "Found GMock sources in ${GMOCK_SRC_DIR}")
+            add_subdirectory("${GMOCK_SRC_DIR}" gmock)
+            set(GMOCK_BOTH_LIBRARIES "gmock_main")
+        else()
+            message(FATAL_ERROR "GMock sources not found build -DBUILD_TESTING=On requested!")
+        endif()
     endif()
 
     #TODO: clean this up

--- a/tests/unit/openssl_lib_mock.cpp
+++ b/tests/unit/openssl_lib_mock.cpp
@@ -48,6 +48,12 @@ void OpenSSLLibMockManager::resetMock()
     _mock = std::make_unique<OpenSSLLibMock>();
 }
 
+void OpenSSLLibMockManager::destroy()
+{
+    std::lock_guard<std::mutex> _lock(_mutex);
+    _mock.reset();
+}
+
 namespace lib
 {
 /**

--- a/tests/unit/openssl_lib_mock.h
+++ b/tests/unit/openssl_lib_mock.h
@@ -409,6 +409,11 @@ public:
      */
     static void resetMock();
 
+    /**
+     * Destroy current mock object to trigger gmock call analysis
+     */
+    static void destroy();
+
 private:
     static std::unique_ptr<OpenSSLLibMock> _mock;
 

--- a/tests/unit/test_opensslwrapper.cpp
+++ b/tests/unit/test_opensslwrapper.cpp
@@ -47,6 +47,7 @@ class OpenSSLWrapperTest : public ::testing::Test
 {
 public:
     void SetUp() override;
+    void TearDown() override;
 
 protected:
     std::string _defaultErrorMessage{"bla bla bla"};
@@ -75,6 +76,11 @@ void OpenSSLWrapperTest::SetUp()
     ON_CALL(_mock(), SSL_ERR_error_string(_, nullptr))
             .WillByDefault(Return(const_cast<char *>(_defaultErrorMessage.c_str())));
     // TODO: Get rid of the uninteresting calls by default here somehow...
+}
+
+void OpenSSLWrapperTest::TearDown()
+{
+    OpenSSLLibMockManager::destroy();
 }
 
 /*


### PR DESCRIPTION
It seems that the static (de)initialization nightmare
hits us with the OpenSSLMockManager class that implements
the singleton. Gmock might not see the (last) mock object
destroyed, does not check the expected calls and returns an
error.

In order to avoid this, explicitly destroy the mock interface
at the end of a test case.